### PR TITLE
Fix switch module test.. kinda

### DIFF
--- a/KCP2/KCP2.ino
+++ b/KCP2/KCP2.ino
@@ -12,8 +12,6 @@
 void setup()
 {
 	Serial.begin(BAUDRATE);
-	
-	//setPinAssignment(); TBD - remove
 		
 	executeTest();
 	

--- a/libraries/Configs/Configs.h
+++ b/libraries/Configs/Configs.h
@@ -14,7 +14,7 @@ Purpose: All configurable settings for Kerbal Control Panel - Mk II
 // Available rates: 300, 600, 1200, 2400, 4800, 9600, 14400, 19200, 28800,
 //					38400, 57600, or 115200.
 // Default: TBD
-const int BAUDRATE = 115200; //TBD: consider dropping this. Might overfill buffer...
+const int BAUDRATE = 19200;
 
 
 

--- a/libraries/Configs/PinAssignment.h
+++ b/libraries/Configs/PinAssignment.h
@@ -2,7 +2,7 @@
 #define PinAssignment_h
 
 #include "Arduino.h"
-
+#include "Switch.h"
 
 /*------------------------------------------------------------------------------
 
@@ -10,12 +10,7 @@ Purpose: Create all HW models and specify Pin Assignment.
 
 ------------------------------------------------------------------------------*/
 
-//void setPinAssignment()
-//{
-
 //Module A
-//Switch switch_test(17, INPUT_PULLUP);
-int v = 5;
-//}
+Switch switch_test(6, INPUT_PULLUP);
 
 #endif

--- a/libraries/Configs/PinAssignment.h
+++ b/libraries/Configs/PinAssignment.h
@@ -11,6 +11,6 @@ Purpose: Create all HW models and specify Pin Assignment.
 ------------------------------------------------------------------------------*/
 
 //Module A
-Switch switch_test(6, INPUT_PULLUP);
+Switch switch_test(17, INPUT_PULLUP);
 
 #endif

--- a/libraries/ElectricalModuleTests/ElectricalModuleTests.h
+++ b/libraries/ElectricalModuleTests/ElectricalModuleTests.h
@@ -11,7 +11,9 @@ Purpose: Output system state for each Module to test electrical wiring.
 ------------------------------------------------------------------------------*/
 void displayModuleA()
 {
-	Serial.print("Switch test: "); Serial.println(v);//switch_test.getState());
+  switch_test.refreshState();
+  Serial.print("Switch test: ");
+  Serial.println(switch_test.getState());
 }
 
 //==============================================================================
@@ -21,7 +23,7 @@ void executeTest()
 	{
 		//Clear screen:
 		Serial.print("\n"); // "\r\n" ?
-		
+
 		//Display Module Status
 		displayModuleA();
 		//displayModuleB();
@@ -36,7 +38,7 @@ void executeTest()
 		//displayModuleK();
 		//displayModuleL();
 		//displayModuleM();
-		
+
 		//Wait
 		delay(200);
 	}


### PR DESCRIPTION
A few suggestions, although my knowledge of CPP is flaky:
1. Lower the baud rate so that my peasant arduino nanos can actually serve the data.
2. Don't declare switch_test in the scope of setPinAssignment() because then nothing else will be able to see it. For now, may as well keep switch_test in global scope.
3. Remember to refresh state of pin so that you pick up changes in pin voltage.
4. As a result of my change in Comment #2, I think you have a volatile situation where if you `#include <ElectricalModuleTests.h>` higher up than `#include <PinAssignment.h>` in main.ino, you'll get an error that `switch_test` isn't declared. You should include PinAssignment.h in ElectricalModuleTests.h.